### PR TITLE
init : log 설정 - logback, log4jdbc 및 lang3, guava 추가

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -14,6 +14,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     //aws
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    // log
+    implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:1.16'
+    // util
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
+    implementation 'com.google.guava:guava:31.0.1-jre'
     //test
     testImplementation group: 'io.rest-assured', name: 'rest-assured', version: '4.3.3'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/api/src/main/resources/log4jdbc.log4j2.properties
+++ b/api/src/main/resources/log4jdbc.log4j2.properties
@@ -1,0 +1,3 @@
+log4jdbc.drivers=org.h2.Driver
+log4jdbc.spylogdelegator.name=net.sf.log4jdbc.log.slf4j.Slf4jSpyLogDelegator
+log4jdbc.dump.sql.maxlinelength=0

--- a/api/src/main/resources/logback.xml
+++ b/api/src/main/resources/logback.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n
+            </Pattern>
+        </layout>
+    </appender>
+
+    <logger name="com.teamherb.bookstoreback" level="DEBUG" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <!-- log4jdbc -->
+    <logger name="jdbc.sqlonly" level="DEBUG"/>
+    <logger name="jdbc.sqltiming" level="INFO"/>
+    <logger name="jdbc.audit" level="OFF"/>
+    <logger name="jdbc.resultset" level="OFF"/>
+    <logger name="jdbc.resultsettable" level="DEBUG"/>
+    <logger name="jdbc.connection" level="WARN"/>
+
+    <root level="DEBUG">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/api/src/test/resources/log4jdbc.log4j2-test.properties
+++ b/api/src/test/resources/log4jdbc.log4j2-test.properties
@@ -1,0 +1,3 @@
+log4jdbc.drivers=org.h2.Driver
+log4jdbc.spylogdelegator.name=net.sf.log4jdbc.log.slf4j.Slf4jSpyLogDelegator
+log4jdbc.dump.sql.maxlinelength=0

--- a/api/src/test/resources/logback-test.xml
+++ b/api/src/test/resources/logback-test.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                >>>>> 로그 출력 : %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n
+            </Pattern>
+        </layout>
+    </appender>
+
+    <logger name="com.teamherb.bookstoreback" level="DEBUG" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <!-- log4jdbc -->
+    <logger name="jdbc.sqlonly" level="INFO"/>
+    <logger name="jdbc.sqltiming" level="DEBUG"/>
+    <logger name="jdbc.audit" level="OFF"/>
+    <logger name="jdbc.resultset" level="OFF"/>
+    <logger name="jdbc.resultsettable" level="DEBUG"/>
+    <logger name="jdbc.connection" level="WARN"/>
+
+    <root level="DEBUG">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
# 변경내용
## 대상
![image](https://user-images.githubusercontent.com/15000594/139539634-f66e3622-4acd-48ce-8df5-0dd97b200a53.png)

## 라이브러리 추가
- api 모듈 내 build.gradle 내 추가
    - log4jdbc-log4j2 : DB Transaction 로그 확인
    - commons-lang3 : 문자열, 배열, 숫자 객체 활용에 용이한 유틸성 기능을 제공
    - guava : Precondition 등에서 제공되는 예외 설정 기능 활용을 위함
- 관련 링크
    - https://www.baeldung.com/apache-commons-collections-vs-guava
    - https://www.baeldung.com/java-commons-lang-3
    - https://blog.outsider.ne.kr/710
    
## Logback 설정 파일 추가
- logback은 spring-boot-starter 에서 기본적으로 사용
    ![image](https://user-images.githubusercontent.com/15000594/139540427-c81fe407-9ca7-4784-9ac2-1970be981f70.png)
- logback.xml 파일을 생성하고 옵션을 설정
    - 로그 레벨을 설정 (root 및 원하는 패키지)
    - console 출력 형식 설정
    - 파일 로깅이 필요한 경우 추가 설정 필요.
- - application.properties와 xml 에 동시에 logging level을 설정하는 경우 properties 에 설정한 값이 우선됩니다.
- 관련 링크
    - https://goddaehee.tistory.com/45
    - https://www.baeldung.com/logback
    - https://mkyong.com/logging/logback-xml-example/
    - https://mkyong.com/logging/log4j2-xml-example/

## log4jdbc-log4j2 사용을 위한 설정 추가
- 해당 라이브러리 사용을 위해 두 가지 수정작업을 했습니다.
    - log4jdbc.log4j2.properties 추가
        - `log4jdbc.spylogdelegator.name` 설정 (필수) 및 옵션 값 설정
        - DB 사용 전까지 in-memory DB인 h2를 활용하고자 `log4jdbc.drivers=org.h2.Driver` 로 설정되어 있습니다. 이부분은 차후 운영되는 DB의 driver로 변경하여 설정할 수 있습니다.
    - spring.datasource 수정
        - `driverClassName` : net.sf.log4jdbc.sql.jdbcapi.DriverSpy
        - `url`: `jdbc:` -> `jdbc:log4jdbc:` 로 수정
- 관련 링크
    - https://frozenpond.tistory.com/86
    - https://log4jdbc.brunorozendo.com/
