### PR TITLE
Refactor/92 : 로그인 방식 추가 (accessToken으로 요청하는 방식 추가)

### DIFF
--- a/api/src/docs/asciidoc/api-docs.adoc
+++ b/api/src/docs/asciidoc/api-docs.adoc
@@ -34,12 +34,17 @@ API 공통적으로 사용되는 상태 코드이다.
 
 == 1. 사용자 인증 관련 (OAuth)
 
-=== 1.1 로그인
+=== 1.1.1 로그인 (web용, redirect 방식)
 - provider에 로그인 요청 (네이버에 로그인 요청 시)
 
 operation::oauth/requestLogin[snippets='http-request,http-response']
 
-- 로그인 후 api token 생성 요청 (provider로부터 accessToken을 발급 받는 절차가 선행되어야 합니다.)
+- 로그인 후 api token 생성 요청 (redirect)
+
+operation::oauth/loginProcessAfterRedirct[snippets='http-request,http-response,response-fields']
+
+=== 1.1.2 로그인 (provider의 accessToken으로 요청 시)
+- accessToken으로 api token 생성 요청
 
 operation::oauth/loginProcess[snippets='http-request,http-response,response-fields']
 

--- a/api/src/docs/asciidoc/api-docs.adoc
+++ b/api/src/docs/asciidoc/api-docs.adoc
@@ -39,7 +39,7 @@ API 공통적으로 사용되는 상태 코드이다.
 
 operation::oauth/requestLogin[snippets='http-request,http-response']
 
-- 로그인 후 api token 생성 요청 (redirect)
+- 로그인 후 api token 생성 요청 (provider로부터 accessToken을 발급 받는 절차가 선행되어야 합니다.)
 
 operation::oauth/loginProcess[snippets='http-request,http-response,response-fields']
 

--- a/api/src/main/java/com/bookwhale/auth/controller/OAuthController.java
+++ b/api/src/main/java/com/bookwhale/auth/controller/OAuthController.java
@@ -62,16 +62,15 @@ public class OAuthController {
      * (provider로 부터 로그인 성공 후) provider에서 전달한 요청 키로 로그인 절차를 진행한다.
      *
      * @param providerType OAuth 로그인 기능 공급자(provider : GOOGLE, NAVER)
-     * @param accessCode   요청 키
-     * @param state        (optional) 네이버 상태값
+     * @param accessToken   요청 키
      * @return
      */
     @GetMapping("/{providerType}/login")
     public ResponseEntity<OAuthLoginResponse> oAuthLoginProcess(
         @PathVariable OAuthProviderType providerType,
-        @RequestParam(name = "code") String accessCode) {
+        @RequestParam(name = "code") String accessToken) {
 
-        OAuthLoginResponse result = oauthService.loginProcess(providerType, accessCode);
+        OAuthLoginResponse result = oauthService.loginProcess(providerType, accessToken);
 
         return ResponseEntity.ok(result);
     }

--- a/api/src/main/java/com/bookwhale/auth/controller/OAuthController.java
+++ b/api/src/main/java/com/bookwhale/auth/controller/OAuthController.java
@@ -39,7 +39,27 @@ public class OAuthController {
     }
 
     /**
+     * (redirectURL 처리 용도)
      * provider 에 로그인이 완료되면 전달받는 요청 키로 로그인 절차를 진행한다.
+     *
+     * @param providerType OAuth 로그인 기능 공급자(provider : GOOGLE, NAVER)
+     * @param accessCode   요청 키
+     * @param state        (optional) 네이버 상태값
+     * @return
+     */
+    @GetMapping("/{providerType}/issueToken")
+    public ResponseEntity<OAuthLoginResponse> oAuthLoginProcess(
+        @PathVariable OAuthProviderType providerType,
+        @RequestParam(name = "code") String accessCode,
+        @RequestParam(name = "state", required = false) String state) {
+
+        OAuthLoginResponse result = oauthService.requestAccessTokenAndIssueApiToken(providerType, accessCode);
+
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * (provider로 부터 로그인 성공 후) provider에서 전달한 요청 키로 로그인 절차를 진행한다.
      *
      * @param providerType OAuth 로그인 기능 공급자(provider : GOOGLE, NAVER)
      * @param accessCode   요청 키
@@ -49,8 +69,7 @@ public class OAuthController {
     @GetMapping("/{providerType}/login")
     public ResponseEntity<OAuthLoginResponse> oAuthLoginProcess(
         @PathVariable OAuthProviderType providerType,
-        @RequestParam(name = "code") String accessCode,
-        @RequestParam(name = "state", required = false) String state) {
+        @RequestParam(name = "code") String accessCode) {
 
         OAuthLoginResponse result = oauthService.loginProcess(providerType, accessCode);
 

--- a/api/src/main/java/com/bookwhale/auth/service/provider/GoogleOAuthProvider.java
+++ b/api/src/main/java/com/bookwhale/auth/service/provider/GoogleOAuthProvider.java
@@ -61,10 +61,10 @@ public class GoogleOAuthProvider implements OAuthProvider {
         return restTemplate.postForEntity(accessTokenRequestURL, params, String.class);
     }
 
-    public ResponseEntity<String> getUserInfoFromProvider(GoogleOAuthToken oAuthToken) {
+    public ResponseEntity<String> getUserInfoFromProvider(String accessToken) {
 
         HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "Bearer " + oAuthToken.getAccessToken());
+        headers.add("Authorization", "Bearer " + accessToken);
 
         HttpEntity<Map<String, String>> request = new HttpEntity(headers);
 

--- a/api/src/main/java/com/bookwhale/auth/service/provider/NaverOAuthProvider.java
+++ b/api/src/main/java/com/bookwhale/auth/service/provider/NaverOAuthProvider.java
@@ -81,10 +81,10 @@ public class NaverOAuthProvider implements OAuthProvider {
             String.class);
     }
 
-    public ResponseEntity<String> getUserInfoFromProvider(NaverOAuthToken oAuthToken) {
+    public ResponseEntity<String> getUserInfoFromProvider(String accessToken) {
 
         HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "Bearer " + oAuthToken.getAccessToken());
+        headers.add("Authorization", "Bearer " + accessToken);
 
         HttpEntity<Map<String, String>> request = new HttpEntity(headers);
 

--- a/api/src/main/resources/config/application-auth.yml
+++ b/api/src/main/resources/config/application-auth.yml
@@ -20,13 +20,13 @@ external-api:
       client-key: ENC(nGQtzCp7nQFf+RfRkpZ4KvtIMo2plbCd)
       base-url: https://nid.naver.com/oauth2.0/authorize
       state: whale
-      callback-url: http://localhost:8080/api/oauth/naver/login
+      callback-url: http://localhost:8080/api/oauth/naver/issueToken
       access-token-url: https://nid.naver.com/oauth2.0/token
     google:
       client-id: ENC(ky7Fs/NURcBOuo7ncPOWrIe0m6ifM0c4QTdnQxwysRSV/8M05qMUbXklav+TauYGmfMVKU7DrFuXo19gWit6yqYvEjZHXahVbSJk6rjAOyCL7fiqTIW8ig==)
       client-key: ENC(afk3fc9o+Nj7mUZZe6OWI9A6IEkHNw28reztrSke9/cggJKgffehT314mJlMk5bm)
       base-url: https://accounts.google.com/o/oauth2
-      callback-url: http://localhost:8080/api/oauth/google/login
+      callback-url: http://localhost:8080/api/oauth/google/issueToken
       access-token-url: https://oauth2.googleapis.com/token
 jwt:
   token:

--- a/api/src/test/java/com/bookwhale/auth/controller/OAuthControllerTest.java
+++ b/api/src/test/java/com/bookwhale/auth/controller/OAuthControllerTest.java
@@ -39,9 +39,25 @@ class OAuthControllerTest extends CommonApiTest {
         when(oauthService.requestAccessTokenAndIssueApiToken(any(), any(String.class))).thenReturn(response);
 
         mockMvc.perform(
-                RestDocumentationRequestBuilders.get("/api/oauth/{providerType}/login", "naver")
+                RestDocumentationRequestBuilders.get("/api/oauth/{providerType}/issueToken", "naver")
                     .param("code", "accessCode")
                     .param("state", "stateString")
+            )
+            .andExpect(status().isOk())
+            .andDo(print())
+            .andDo(OAuthDocumentation.loginProcessAfterRedirct());
+    }
+
+    @Test
+    @DisplayName("전달받는 요청 키와 함께 요청하면 로그인 절차를 진행한다.")
+    void oAuthLoginProcessWithAccessToken() throws Exception {
+        var response = new OAuthLoginResponse("apiToken", "refreshToken");
+
+        when(oauthService.loginProcess(any(), any(String.class))).thenReturn(response);
+
+        mockMvc.perform(
+                RestDocumentationRequestBuilders.get("/api/oauth/{providerType}/login", "naver")
+                    .param("code", "accessToken")
             )
             .andExpect(status().isOk())
             .andDo(print())

--- a/api/src/test/java/com/bookwhale/auth/controller/OAuthControllerTest.java
+++ b/api/src/test/java/com/bookwhale/auth/controller/OAuthControllerTest.java
@@ -36,7 +36,7 @@ class OAuthControllerTest extends CommonApiTest {
     void oAuthLoginProcessAfterProviderLogin() throws Exception {
         var response = new OAuthLoginResponse("apiToken", "refreshToken");
 
-        when(oauthService.loginProcess(any(), any(String.class))).thenReturn(response);
+        when(oauthService.requestAccessTokenAndIssueApiToken(any(), any(String.class))).thenReturn(response);
 
         mockMvc.perform(
                 RestDocumentationRequestBuilders.get("/api/oauth/{providerType}/login", "naver")

--- a/api/src/test/java/com/bookwhale/auth/docs/OAuthDocumentation.java
+++ b/api/src/test/java/com/bookwhale/auth/docs/OAuthDocumentation.java
@@ -26,14 +26,24 @@ public class OAuthDocumentation {
             parameterWithName("providerType").description("OAuth 로그인 기능 공급자 (GOOGLE, NAVER)")));
     }
 
-    public static RestDocumentationResultHandler loginProcess() {
-        return document("oauth/loginProcess", preprocessRequest(prettyPrint()),
+    public static RestDocumentationResultHandler loginProcessAfterRedirct() {
+        return document("oauth/loginProcessAfterRedirct", preprocessRequest(prettyPrint()),
             preprocessResponse(prettyPrint()), pathParameters(
                 parameterWithName("providerType").description("OAuth 로그인 기능 공급자 (GOOGLE, NAVER)")),
             requestParameters(
                 parameterWithName("code").description("provider 에 로그인이 완료되면 전달받는 요청 키"),
                 parameterWithName("state").description("provider 에 로그인이 완료되면 전달받는 요청 키")
                     .optional()), responseFields(getTokenResponseFieldDescriptor()));
+    }
+
+    public static RestDocumentationResultHandler loginProcess() {
+        return document("oauth/loginProcess", preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()), pathParameters(
+                parameterWithName("providerType").description("OAuth 로그인 기능 공급자 (GOOGLE, NAVER)")),
+            requestParameters(
+                parameterWithName("code").description("provider로 부터 전달받은 accessToken")
+                ),
+            responseFields(getTokenResponseFieldDescriptor()));
     }
 
     public static RestDocumentationResultHandler refreshLoginProcess() {


### PR DESCRIPTION
accessToken으로 요청하여 apiToken을 발급할 수 있도록 end-point를 추가

- accessToken으로 요청 : 
    - http://localhost:8080/api/oauth/naver/login?code=accessToken
- redirect 방식 (기존 구현) : 
    - http://localhost:8080/api/oauth/naver