### PR TITLE
#133 : bugfix - 사용자 탈퇴 처리를 email 값 hashing 으로 변경

### DIFF
--- a/api/src/main/java/com/bookwhale/auth/controller/OAuthController.java
+++ b/api/src/main/java/com/bookwhale/auth/controller/OAuthController.java
@@ -39,8 +39,7 @@ public class OAuthController {
     }
 
     /**
-     * (redirectURL 처리 용도)
-     * provider 에 로그인이 완료되면 전달받는 요청 키로 로그인 절차를 진행한다.
+     * (redirectURL 처리 용도) provider 에 로그인이 완료되면 전달받는 요청 키로 로그인 절차를 진행한다.
      *
      * @param providerType OAuth 로그인 기능 공급자(provider : GOOGLE, NAVER, KAKAO)
      * @param accessCode   요청 키
@@ -53,7 +52,8 @@ public class OAuthController {
         @RequestParam(name = "code") String accessCode,
         @RequestParam(name = "state", required = false) String state) {
 
-        OAuthLoginResponse result = oauthService.requestAccessTokenAndIssueApiToken(providerType, accessCode);
+        OAuthLoginResponse result = oauthService.requestAccessTokenAndIssueApiToken(providerType,
+            accessCode);
 
         return ResponseEntity.ok(result);
     }
@@ -62,7 +62,7 @@ public class OAuthController {
      * (provider로 부터 로그인 성공 후) provider에서 전달한 요청 키로 로그인 절차를 진행한다.
      *
      * @param providerType OAuth 로그인 기능 공급자(provider : GOOGLE, NAVER, KAKAO)
-     * @param accessToken   요청 키
+     * @param accessToken  요청 키
      * @return
      */
     @GetMapping("/{providerType}/login")
@@ -103,7 +103,7 @@ public class OAuthController {
     }
 
     /**
-     * 로그인 사용자의 정보를 제거하고 발급 시 저장했던 refreshToken 정보를 제거한다.
+     * 로그인 사용자의 정보를 hashing 하고 발급 시 저장했던 refreshToken 정보를 제거한다.
      *
      * @param user           로그인 한 사용자 (token)
      * @param refreshRequest apiToken, refreshToken 문자열
@@ -113,8 +113,7 @@ public class OAuthController {
     public ResponseEntity<OAuthResultResponse> withdrawalUser(
         @CurrentUser User user,
         @Valid @RequestBody OAuthRefreshLoginRequest refreshRequest) {
-        OAuthResultResponse result = oauthService.withdrawal(refreshRequest, user);
-
+        OAuthResultResponse result = oauthService.withdrawalUser(refreshRequest, user);
         return ResponseEntity.ok(result);
     }
 

--- a/api/src/test/java/com/bookwhale/auth/controller/OAuthControllerTest.java
+++ b/api/src/test/java/com/bookwhale/auth/controller/OAuthControllerTest.java
@@ -107,7 +107,7 @@ class OAuthControllerTest extends CommonApiTest {
         String requestBody = objectMapper.writeValueAsString(refreshRequest);
         var response = new OAuthResultResponse("회원 탈퇴 완료되었습니다.");
 
-        when(oauthService.withdrawal(any(), any())).thenReturn(response);
+        when(oauthService.withdrawalUser(any(), any())).thenReturn(response);
 
         mockMvc.perform(post("/api/oauth/withdrawal")
                 .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")

--- a/core/src/main/java/com/bookwhale/auth/service/OauthService.java
+++ b/core/src/main/java/com/bookwhale/auth/service/OauthService.java
@@ -177,7 +177,7 @@ public class OauthService {
     }
 
     @Transactional
-    public OAuthResultResponse withdrawal(OAuthRefreshLoginRequest refreshRequest, User user) {
+    public OAuthResultResponse withdrawalUser(OAuthRefreshLoginRequest refreshRequest, User user) {
         // step1 : refresh token 확인 후 삭제
         String refreshToken = refreshRequest.getRefreshToken();
         ClaimsForRefresh refreshClaim = apiToken.verifyForRefresh(refreshToken);

--- a/core/src/main/java/com/bookwhale/common/utils/HashingUtil.java
+++ b/core/src/main/java/com/bookwhale/common/utils/HashingUtil.java
@@ -1,0 +1,47 @@
+package com.bookwhale.common.utils;
+
+import com.bookwhale.common.exception.CustomException;
+import com.bookwhale.common.exception.ErrorCode;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class HashingUtil {
+
+    public static String sha256(String str) {
+        return hashingFromGuava(str, "sha-256");
+    }
+
+    private static String hashingFromMessageDigest(String str, String algorithm) {
+        try {
+            MessageDigest messageDigest = MessageDigest.getInstance(algorithm);
+            messageDigest.update(str.getBytes());
+            return String.format("%040x", new BigInteger(1, messageDigest.digest()));
+        } catch (NoSuchAlgorithmException e) {
+            log.error("hashing 처리 오류 ({})", algorithm, e);
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // 'com.google.common.hash.Hashing' is marked unstable with @Beta
+    private static String hashingFromGuava(String str, String algorithm) {
+        try {
+            HashFunction hashFunction = Hashing.sha256();
+            if ("SHA-384".equalsIgnoreCase(algorithm)) {
+                hashFunction = Hashing.sha384();
+            } else if ("SHA-512".equalsIgnoreCase(algorithm)) {
+                hashFunction = Hashing.sha512();
+            }
+            return hashFunction.hashString(str, StandardCharsets.UTF_8)
+                .toString();
+        } catch (Exception e) {
+            log.error("hashing 처리 오류 ({})", algorithm, e);
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/core/src/main/java/com/bookwhale/user/domain/User.java
+++ b/core/src/main/java/com/bookwhale/user/domain/User.java
@@ -55,4 +55,10 @@ public class User extends BaseEntity {
     public void deleteProfile() {
         this.profileImage = null;
     }
+
+    public void convertUnavailableUser(String hashedEmail) {
+        this.nickname = "** 탈퇴한 사용자 **";
+        this.email = hashedEmail;
+        deleteProfile();
+    }
 }

--- a/core/src/main/java/com/bookwhale/user/service/UserService.java
+++ b/core/src/main/java/com/bookwhale/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.bookwhale.auth.domain.info.UserInfo;
 import com.bookwhale.common.exception.CustomException;
 import com.bookwhale.common.exception.ErrorCode;
 import com.bookwhale.common.upload.FileUploader;
+import com.bookwhale.common.utils.HashingUtil;
 import com.bookwhale.user.domain.User;
 import com.bookwhale.user.domain.UserRepository;
 import com.bookwhale.user.dto.ProfileResponse;
@@ -25,11 +26,8 @@ public class UserService {
     private final FileUploader fileUploader;
 
     public void createUser(UserInfo userInfo) {
-        User user = User.builder()
-            .email(userInfo.getEmail())
-            .nickname(userInfo.getName())
-            .profileImage(userInfo.getPicture())
-            .build();
+        User user = User.builder().email(userInfo.getEmail()).nickname(userInfo.getName())
+            .profileImage(userInfo.getPicture()).build();
         userRepository.save(user);
     }
 
@@ -53,8 +51,10 @@ public class UserService {
     }
 
     public void withdrawalUser(User user) {
-        User targetUser = findUserByEmail(user.getEmail());
-        userRepository.delete(targetUser);
+        String email = user.getEmail();
+        User targetUser = findUserByEmail(email);
+        targetUser.convertUnavailableUser(HashingUtil.sha256(email));
+        userRepository.saveAndFlush(targetUser);
     }
 
     public ProfileResponse uploadProfileImage(User user, MultipartFile image) {

--- a/core/src/test/java/com/bookwhale/common/utils/HashingUtilTest.java
+++ b/core/src/test/java/com/bookwhale/common/utils/HashingUtilTest.java
@@ -1,0 +1,20 @@
+package com.bookwhale.common.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+class HashingUtilTest {
+
+    @Test
+    void hashingString() {
+        String testStr = "test@test.com";
+        String hashedStr = HashingUtil.sha256(testStr);
+
+        assertThat(testStr).isNotEqualTo(hashedStr);
+        assertThat(hashedStr.getBytes(StandardCharsets.UTF_8).length).isEqualTo(64);
+    }
+}


### PR DESCRIPTION
# 개요
- 회원탈퇴 요청시 에러번호 500, 코드 S_001 발생
{"status":500,"message":"서버에 문제가 생겼습니다.","code":"S_001","errors":null}

# 수정사항
- 회원 탈퇴를 물리적 삭제가 아닌 조회가 불가능하도록 변경
    - 탈퇴한 사용자의 nickname은 `** 탈퇴한 사용자 **` 로 변경
    - email 값을 `SHA-256`으로 hashing (64 bytes) 